### PR TITLE
Fix github token reference

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,6 @@ runs:
       shell: bash
       run: ./check_email_pr.sh
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
         PULL_NUMBER: ${{ github.event.number }}
         COMMITS_COUNT: ${{ github.event.pull_request.commits }}


### PR DESCRIPTION
The job can use the `secrets.` syntax, but an action should use the `github.` context [1].

[1] https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context