### PR TITLE
Fix get_pr_commits function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,13 @@ on:
       - "src/**"
       - "test/**"
       - "check_email_pr.sh"
+      - ".github/workflows/ci.yml"
   push:
     paths:
       - "src/**"
       - "test/**"
       - "check_email_pr.sh"
+      - ".github/workflows/ci.yml"
 
 jobs:
   email_check_ci:

--- a/check_email_pr.sh
+++ b/check_email_pr.sh
@@ -2,12 +2,13 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
 
-debug() { echo "::debug::$1" ; } # message
+debug() { echo "::debug::$1" >&2 ; } # message
+error() { echo "::error::$1" >&2 ; } # message
 
 # https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-commits-on-a-pull-request
 get_pr_commits() {
     [ -n "$TEST_MODE" ] && cat ./test/pr_list_commits.json && return
-    [ "$COMMITS_COUNT" -gt 100 ] && echo "::debug::Needs pagination"
+    [ "$COMMITS_COUNT" -gt 100 ] && debug "Needs pagination"
     # TODO: Handle paginated results
     # https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers
     curl -L --no-progress-meter \
@@ -28,7 +29,7 @@ usage() { # error_message [error_code]
     usage: $prog [--test]
 
 EOF
-    [ $# -gt 0 ] && echo "Error - $@" >&2
+    [ $# -gt 0 ] && error "$@"
     [ $# -gt 1 ] && exit $2
     exit 10
 }

--- a/check_email_pr.sh
+++ b/check_email_pr.sh
@@ -11,11 +11,13 @@ get_pr_commits() {
     [ "$COMMITS_COUNT" -gt 100 ] && debug "Needs pagination"
     # TODO: Handle paginated results
     # https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28#using-link-headers
+    local endpoint="$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER/commits?per_page=$COMMITS_COUNT"
+    echo "::debug::Getting commits from $endpoint"
     curl -L --no-progress-meter \
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer $GITHUB_TOKEN" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
-        "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER/commits?per_page=$COMMITS_COUNT"
+        "$endpoint"
 }
 
 split_commits_and_add_metadata() {

--- a/check_email_pr.sh
+++ b/check_email_pr.sh
@@ -15,7 +15,7 @@ get_pr_commits() {
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer $GITHUB_TOKEN" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
-        "https://api.github.com/repos/$GITHUB_REPOSITORY_OWNER/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER/commits?per_page=$COMMITS_COUNT"
+        "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER/commits?per_page=$COMMITS_COUNT"
 }
 
 split_commits_and_add_metadata() {

--- a/src/check_email.sh
+++ b/src/check_email.sh
@@ -6,9 +6,9 @@
 # addresses are used for commits to Proprietary and Open Source repositories.
 ########################################################################
 
-debug() { [ "$VERBOSE" = "true" ] && echo "::debug::$1" ; } # message
-error() { echo "::error::$1" ; HAS_ERRORS=1 ; } # message
-warning() { echo "::warning::$1" ; } # message
+debug() { [ "$VERBOSE" = "true" ] && echo "::debug::$1" >&2 ; } # message
+error() { echo "::error::$1" >&2 ; HAS_ERRORS=1 ; } # message
+warning() { echo "::warning::$1" >&2 ; } # message
 
 json_val_by_key() { # key > value
     echo "$JSON" | jq -r "$1 // empty"


### PR DESCRIPTION
The get_pr_commits function was outputting a debug message to stdout, which caused jq to fail. Fix that issue and also fix the issue with duplicate GITHUB_REPOSITORY_OWNER, while improving the debug messages and GITHUB_API_URL portability.