### PR TITLE
Fix path to script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Check emails
       id: check_emails
       shell: bash
-      run: ./check_email_pr.sh
+      run: ${GITHUB_ACTION_PATH}/check_email_pr.sh
       env:
         GITHUB_TOKEN: ${{ github.token }}
         PULL_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
When the action is used from another repo, we need to prefix the action path.